### PR TITLE
Ignore out directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ gradle.properties
 /unknownLink2.xml
 /hs_err_pid8155.log
 /carlRobot2.xml
+out
+


### PR DESCRIPTION
The `out` directory should be ignored.