### PR TITLE
Log file format update, add line spacing and categorize messages

### DIFF
--- a/src/main/java/com/neuronrobotics/sdk/common/Log.java
+++ b/src/main/java/com/neuronrobotics/sdk/common/Log.java
@@ -36,11 +36,9 @@ import com.neuronrobotics.sdk.util.ThreadUtil;
  *
  */
 public class Log {
-	
-	
-	
+
 	/** The Constant LOG. */
-	public static final int LOG =-1;
+	public static final int LOG = -1;
 	
 	/** The Constant INFO. */
 	public static final int INFO = 0;
@@ -63,7 +61,7 @@ public class Log {
 	
 	/** The date format. */
 	private DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss:SS");
-	
+
 	/** The minprintlevel. */
 	private int minprintlevel = WARNING;
 	
@@ -75,19 +73,24 @@ public class Log {
 	
 	/** The out stream. */
 	private static PrintStream outStream = System.out;
+
 	/** The out stream. */
 	private static PrintStream errStream = System.err;	
+
 	/** The out stream. */
 	private static PrintStream mirrorStream = System.out;		
+
 	/** The use colored prints. */
-	private boolean useColoredPrints=false;
+	private boolean useColoredPrints = false;
 	
 	private Thread logFileThread = null;
 	
-	private File log=null;
+	private File log = null;
 
 	private ByteList incomingErr;
 	private ByteList incomingOut;
+
+	private String lastCallingClass = "";
 
 	/**
 	 * Instantiates a new log.
@@ -159,23 +162,16 @@ public class Log {
 	 */
 	private void add(String message, int importance) {
 		
-		if( importance < minprintlevel) {
+		if (importance < minprintlevel)
 			return;
-		}
-		if(m==null)
-			m = new Message(message, importance);
-		else{
-			m.init(message, importance);
-		}
-		//messages.add(m);
 
-		
-		if( systemprint) {
+		if (m == null)
+			m = new Message(message, importance);
+		else
+			m.init(message, importance);
+
+		if (systemprint)
 			outStream.println(m.toString());
-		}
-		
-		
-		
 	}
 	
 	/**
@@ -190,11 +186,11 @@ public class Log {
 	/**
 	 * Enable printing of debug output.
 	 */
-	
 	public static void enableDebugPrint() {
 		Log.enableSystemPrint(true);
 		Log.setMinimumPrintLevel(DEBUG);
 	}
+
 	public static void disablePrint() {
 		Log.enableSystemPrint(false);
 	}
@@ -204,7 +200,6 @@ public class Log {
 	 *
 	 * @param flag the flag
 	 */
-	
 	public static void enableDebugPrint(boolean flag) {
 		Log.enableSystemPrint(flag);
 		Log.setMinimumPrintLevel(DEBUG);
@@ -213,7 +208,6 @@ public class Log {
 	/**
 	 * Enable printing of debug output.
 	 */
-	
 	public static void enableInfoPrint() {
 		Log.enableSystemPrint(true);
 		Log.setMinimumPrintLevel(INFO);
@@ -222,7 +216,6 @@ public class Log {
 	/**
 	 * Enable printing of debug output.
 	 */
-	
 	public static void enableWarningPrint() {
 		Log.enableSystemPrint(true);
 		Log.setMinimumPrintLevel(WARNING);
@@ -231,12 +224,10 @@ public class Log {
 	/**
 	 * Enable printing of debug output.
 	 */
-	
 	public static void enableErrorPrint() {
 		Log.enableSystemPrint(true);
 		Log.setMinimumPrintLevel(ERROR);
 	}
-	
 	
 	/**
 	 * Set the minimum level of importance to dsplay.
@@ -263,7 +254,7 @@ public class Log {
 	 * @return The log instance.
 	 */
 	public static Log instance() {
-		if(instance == null) {
+		if (instance == null) {
 			instance = new Log();
 		}
 		return instance;
@@ -290,6 +281,7 @@ public class Log {
 			return "Log";
 		}
 	}
+
 	/**
 	 * Get a string describing the given importance level.
 	 *
@@ -297,7 +289,7 @@ public class Log {
 	 * @return the importance
 	 */
 	public String getImportanceColor(int importance) {
-		if(isUseColoredPrints()){
+		if (isUseColoredPrints()) {
 			switch(importance) {
 			case INFO:
 				return "\033[92m";// green
@@ -314,9 +306,7 @@ public class Log {
 		}
 		return "";
 	}
-	
 
-	
 	/**
 	 * Get the current output PrintStream.
 	 *
@@ -370,26 +360,41 @@ public class Log {
 		 * @param message the message
 		 * @param importance the importance
 		 */
-		public void init(String message, int importance){
+		public void init(String message, int importance) {
 			this.message = message;
 			this.importance = importance;
 			datetime = new Date();
-		      try
-		      {
-		         throw new Exception("Who called me?");
-		      }
-		      catch( Exception e )
-		      {
-		    	 callingClass= e.getStackTrace()[3].getClassName()+":"+e.getStackTrace()[3].getMethodName();
-		      }
+
+			try
+			{
+				throw new Exception("Who called me?");
+			}
+			catch( Exception e )
+			{
+				callingClass = e.getStackTrace()[3].getClassName() + ":" + e.getStackTrace()[3].getMethodName();
+			}
 		}
 		
 		/* (non-Javadoc)
 		 * @see java.lang.Object#toString()
 		 */
 		public String toString() {
-			//return "\t\t\t\t[" + dateFormat.format(datetime) + "] " + " " + getImportance(importance) +" "+callingClass+ " :\n"+ message;
-			return getImportanceColor(importance)+"[" + dateFormat.format(datetime) + "] " + " " + getImportance(importance) +" "+callingClass+ " :\n\t"+ message+getColorNormalizationCode();
+
+			// First logfile line
+			if (lastCallingClass.isEmpty()) {
+
+				lastCallingClass = "\n======== [" + dateFormat.format(datetime) + "] " + message + " ========";
+				dateFormat = new SimpleDateFormat("HH:mm:ss.SS");
+
+				return lastCallingClass;
+			}
+
+			if (lastCallingClass.equals(getImportance(importance) + " " + callingClass))
+				return getImportanceColor(importance) + "  [" + dateFormat.format(datetime) + "] " +  getColorNormalizationCode() + message;
+
+			lastCallingClass = getImportance(importance) + " " + callingClass;
+
+			return "\n" + getImportanceColor(importance) + lastCallingClass + ":\n  [" + dateFormat.format(datetime) + "] " + getColorNormalizationCode() + message;
 		}
 	}
 	
@@ -398,10 +403,8 @@ public class Log {
 	 *
 	 * @return the color normalization code
 	 */
-	private String getColorNormalizationCode(){
-		if(isUseColoredPrints())
-			return "\033[39m";
-		return "";
+	private String getColorNormalizationCode() {
+		return isUseColoredPrints() ? "\033[39m" : "";
 	}
 	
 	/**
@@ -409,7 +412,7 @@ public class Log {
 	 *
 	 * @return true, if is use colored prints
 	 */
-	public static  boolean isUseColoredPrints() {
+	public static boolean isUseColoredPrints() {
 		return instance().useColoredPrints;
 	}
 	
@@ -441,9 +444,9 @@ public class Log {
 	}
 
 	public static void setFile(File logfile) {
-		instance().systemprint=true;
-		instance.log=null;
-		if(instance.logFileThread!=null) {
+		instance().systemprint = true;
+		instance.log = null;
+		if (instance.logFileThread != null) {
 			instance.logFileThread.interrupt();
 			try {
 				instance.logFileThread.join();
@@ -453,11 +456,11 @@ public class Log {
 			}
 		}
 
-		instance.log=logfile;
-		instance.logFileThread=new Thread(()->{
+		instance.log = logfile;
+		instance.logFileThread = new Thread(()->{
 			instance.incomingErr = new ByteList();
 			
-			OutputStream streamErr =  new OutputStream() {
+			OutputStream streamErr = new OutputStream() {
 				@Override
 				public void write(int b) throws IOException {
 					instance.incomingErr.add(b);
@@ -465,7 +468,7 @@ public class Log {
 			};
 			instance.incomingOut = new ByteList();
 			
-			OutputStream streamOut =  new OutputStream() {
+			OutputStream streamOut = new OutputStream() {
 				@Override
 				public void write(int b) throws IOException {
 					instance.incomingOut.add(b);
@@ -474,17 +477,19 @@ public class Log {
 			System.setOut(new PrintStream(streamOut));
 			System.setErr(new PrintStream(streamErr));
 			setOutStream(new PrintStream(streamErr));
-			while (instance.log!=null) {
+
+			while (instance.log != null) {
 				try {
 					Thread.sleep(149);
 				} catch (InterruptedException e) {
 					return;
 				}
+
 				if (instance.incomingOut.size() > 0)
 					try {
 						String text = instance.incomingOut.asString();
 						instance.incomingOut.clear();
-						if (text != null && text.length() > 0){
+						if ((text != null) && (text.length() > 0)) {
 							//Files.writeString(logfile.toPath(), text, StandardCharsets.UTF_8, StandardOpenOption.APPEND); // java 11+
 							Files.write(logfile.toPath(), text.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
 							mirrorStream.println(text);
@@ -493,11 +498,12 @@ public class Log {
 					} catch (Exception e) {
 						e.printStackTrace();
 					}
+
 				if (instance.incomingErr.size() > 0)
 					try {
 						String text = instance.incomingErr.asString();
 						instance.incomingErr.clear();
-						if (text != null && text.length() > 0){
+						if ((text != null) && (text.length() > 0)) {
 							//Files.writeString(logfile.toPath(), text, StandardCharsets.UTF_8, StandardOpenOption.APPEND); // java 11+
 							Files.write(logfile.toPath(), text.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
 							errStream.println(text);
@@ -510,12 +516,13 @@ public class Log {
 		});
 		instance.logFileThread.start();
 	}
+
 	public static void flush() {
 		setOutStream(outStream);
 		System.setOut(outStream);
 		System.setErr(outStream);
-		instance.log=null;
-		while(instance.incomingOut.size() > 0 ||instance.incomingErr.size() > 0 ) {
+		instance.log = null;
+		while ((instance.incomingOut.size() > 0) || (instance.incomingErr.size() > 0 )) {
 			try {
 				Thread.sleep(10);
 			} catch (InterruptedException e) {

--- a/src/main/java/com/neuronrobotics/sdk/common/Log.java
+++ b/src/main/java/com/neuronrobotics/sdk/common/Log.java
@@ -97,7 +97,7 @@ public class Log {
 	 */
 	private Log() {
 		// private for singleton pattern
-		add(SDKBuildInfo.getSDKVersionString(), INFO);
+		// add(SDKBuildInfo.getSDKVersionString(), INFO);
 	}
 
 	/**
@@ -383,10 +383,10 @@ public class Log {
 			// First logfile line
 			if (lastCallingClass.isEmpty()) {
 
-				lastCallingClass = "\n======== [" + dateFormat.format(datetime) + "] " + message + " ========";
+				lastCallingClass = "======== [" + dateFormat.format(datetime) + "] " + message + " ========";
 				dateFormat = new SimpleDateFormat("HH:mm:ss.SS");
 
-				return lastCallingClass;
+				return lastCallingClass.toString();
 			}
 
 			if (lastCallingClass.equals(getImportance(importance) + " " + callingClass))
@@ -515,6 +515,7 @@ public class Log {
 			}
 		});
 		instance.logFileThread.start();
+        info(SDKBuildInfo.getSDKVersionString());
 	}
 
 	public static void flush() {


### PR DESCRIPTION
Log file format update, add line spacing and categorize messages.

Log file looks something like shown below.

======== [2026/01/25 02:53:18:561] Log file set to C:\Users\Cadoodle\Documents\CaDoodle-workspace\cadoodleLog.txt ========

```
Debug com.commonwealthrobotics.Main:main:
  [02:53:18.566] Git Cache zip exists C:\Users\Cadoodle\bin\CaDoodle-ApplicationInstall\0.29.6\gitcache.zip

Debug com.neuronrobotics.bowlerstudio.scripting.DownloadManager:unzip:
  [02:53:18.567] Unzipping gitcache.zip into C:\Users\Cadoodle\Documents\CaDoodle-workspace\gitcache

Debug com.commonwealthrobotics.Main:main:
  [02:53:18.856] Application at C:\Users\Cadoodle\bin\CaDoodle-ApplicationInstall\0.29.6\CaDoodle-Application.jar is Found
  [02:53:18.857] Got command argument: "-XX:MaxRAMPercentage=95 --add-exports javafx.graphics/com.sun.javafx.css=ALL-UNNAMED --add-exports javafx.controls/com.sun.javafx.scene.control.behavior=ALL-UNNAMED --add-exports javafx.controls/com.sun.javafx.scene.control=ALL-UNNAMED --add-exports javafx.base/com.sun.javafx.event=ALL-UNNAMED --add-exports javafx.controls/com.sun.javafx.scene.control.skin.resources=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.util=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.scene.input=ALL-UNNAMED --add-opens javafx.graphics/javafx.scene=ALL-UNNAMED"
  [02:53:18.858] Passed In File at D:\git\CaDoodle-Application\-XX:MaxRAMPercentage=95 --add-exports javafx.graphics\com.sun.javafx.css=ALL-UNNAMED --add-exports javafx.controls\com.sun.javafx.scene.control.behavior=ALL-UNNAMED --add-exports javafx.controls\com.sun.javafx.scene.control=ALL-UNNAMED --add-exports javafx.base\com.sun.javafx.event=ALL-UNNAMED --add-exports javafx.controls\com.sun.javafx.scene.control.skin.resources=ALL-UNNAMED --add-exports javafx.graphics\com.sun.javafx.util=ALL-UNNAMED --add-exports javafx.graphics\com.sun.javafx.scene.input=ALL-UNNAMED --add-opens javafx.graphics\javafx.scene=ALL-UNNAMED
  [02:53:18.858] Not a doodle file -xx:maxrampercentage=95 --add-exports javafx.graphics/com.sun.javafx.css=all-unnamed --add-exports javafx.controls/com.sun.javafx.scene.control.behavior=all-unnamed --add-exports javafx.controls/com.sun.javafx.scene.control=all-unnamed --add-exports javafx.base/com.sun.javafx.event=all-unnamed --add-exports javafx.controls/com.sun.javafx.scene.control.skin.resources=all-unnamed --add-exports javafx.graphics/com.sun.javafx.util=all-unnamed --add-exports javafx.graphics/com.sun.javafx.scene.input=all-unnamed --add-opens javafx.graphics/javafx.scene=all-unnamed

Error com.neuronrobotics.bowlerstudio.SplashManager:initialize:
  [02:53:18.859] No splash screen availible!

Debug com.neuronrobotics.bowlerstudio.SplashManager:waitForUpdate:
  [02:53:18.946] Waiting for splash to open before moving on
  [02:53:19.47] Waiting for splash to open before moving on

Debug com.neuronrobotics.bowlerstudio.PsudoSplash:lambda$new$3:
  [02:53:19.108] Loading splash image: jar:file:/D:/GIT/CaDoodle-Application/build/libs/CaDoodle-Application.jar!/com/commonwealthrobotics/SourceIcon.png

Debug com.neuronrobotics.bowlerstudio.SplashManager:waitForUpdate:
  [02:53:19.148] Waiting for splash to open before moving on
```
